### PR TITLE
[Feature] Add a Makefile for ease of use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ COPY . /elevator
 
 WORKDIR /elevator/build
 
-RUN cmake -DBUILD_TESTING=ON ..
+ARG tests=ON
+RUN cmake -DBUILD_TESTING=$tests ..
 RUN cmake --build .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+run:
+	docker build -f ./Dockerfile --build-arg tests=OFF --tag=elevator_run:latest .
+	docker run --name run_elevator -w /elevator/build/src -it elevator_run:latest
+
+start_run:
+	docker start -i run_elevator
+
+tests:
+	docker build -f ./Dockerfile --tag=elevator_test:latest .
+	docker run --name test_elevator -w /elevator/build/test -it elevator_test:latest
+
+start_tests:
+	docker start -i test_elevator
+
+clean:
+	docker container rm -f run_elevator
+	docker image rm -f elevator_run:latest
+
+	docker container rm -f test_elevator
+	docker image rm -f elevator_test:latest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# elevator
+
+This repository contains all the necessary tooling to build, install and test an executable that computes the total travel time of an elevator given a specified set of floors to visit.
+
+## Environment
+
+The following assumes `docker` is installed. The repository implements a `Makefile` for ease of use if running from a Linux environment.
+
+## Running the executable
+
+To run the executable:
+```
+$> make run
+$> ./run_elevator -h
+
+Runs the elevator over a given list of floors.
+Usage:
+  run_elevator [OPTION...] [optional args]
+
+      --floors arg      A list of ints representing desired floors. Example
+                        input --floors=12,2,9,1,32
+  -t, --floor_time arg  A double representing the travel time between
+                        floors (default: 10)
+  -h, --help            Print usage and exit
+
+```
+Usage example:
+```
+$> ./run_elevator --floors=12,2,9,1,32 -t 5
+
+Total travel time: 280
+Floors visited (in order): 12 2 9 1 32
+```
+Use `make start_run` to shell back into the container if `make run` was called previously but the shell is no longer active.
+
+## Running the tests
+
+To run the tests:
+```
+$> make tests
+$> ./test_elevator
+
+Randomness seeded to: 634903484
+===============================================================================
+All tests passed (6 assertions in 3 test cases)
+```
+The test suite makes use of the [Catch2](https://github.com/catchorg/Catch2) unit testing framework.
+
+Use `make start_tests` to shell back into the testing container if `make tests` was called previously but the shell is no longer active.
+
+## Cleanup
+A `make clean` target has also been included to help with cleanup. This will forcefully remove all containers and images created from the above steps.

--- a/src/run_elevator.cpp
+++ b/src/run_elevator.cpp
@@ -5,7 +5,7 @@
 
 int main(int argc, char** argv) {
     cxxopts::Options options("run_elevator",
-        "Runs the elevator over given a list of floors.");
+        "Runs the elevator over a given list of floors.");
 
     options.positional_help("[optional args]").show_positional_help();
 


### PR DESCRIPTION
The goal of this PR is to accomplish the following:

- Introduce a `Makefile` to help simplify the command line interface for the developer
- Make is easier to build an image/run a container with/without Catch2 depending on whether or not the user wants to run unit tests
- Add a repository README to describe usage
