### PR TITLE
[Bugfix] Consecutive/repeated floors should only show up once

### DIFF
--- a/src/elevator_controller.cpp
+++ b/src/elevator_controller.cpp
@@ -6,13 +6,21 @@ using namespace std;
 
 RESULT ElevatorController::add_floors(vector<int>& floors, double floor_time) {
     int num_floors = 0;
+    vector<int> floors_visited = {floors.front()};
     for (int i {1}; i < floors.size(); ++i) {
-        num_floors += abs(floors[i] - floors[i-1]);
+        int last_floor = floors[i-1];
+        int next_floor = floors[i];
+        // We want consecutively repeated floors to show up once in our list of
+        // visited floors
+        if (next_floor != last_floor) {
+            num_floors += abs(next_floor - last_floor);
+            floors_visited.push_back(next_floor);
+        }
     };
 
     RESULT result;
     result.travel_time = num_floors * floor_time;
-    result.floors_visited = floors;
+    result.floors_visited = floors_visited;
 
     return result;
 }

--- a/test/test_elevator.cpp
+++ b/test/test_elevator.cpp
@@ -11,6 +11,15 @@ TEST_CASE("Normal elevator operations", "[nominal]") {
     REQUIRE(result.floors_visited == floors);
 };
 
+TEST_CASE("Repeated consecutive floors given", "[repeated]") {
+    std::vector<int> floors = {12, 12, 2, 9, 9, 9, 1, 32, 32};
+    ElevatorController controller;
+    RESULT result = controller.add_floors(floors);
+    REQUIRE(result.travel_time == 560);
+    std::vector<int> floors_visited = {12, 2, 9, 1, 32};
+    REQUIRE(result.floors_visited == floors_visited);
+};
+
 TEST_CASE("Modified floor travel time", "[floor_time]") {
     std::vector<int> floors = {12, 2, 9, 1, 32};
     double floor_time = 8.6;


### PR DESCRIPTION
A user could input consecutively repeated floors; however, we cannot "visit" a floor twice in a row. This commit ensures that the output of our visited floors does not have consecutive repetition. This commit also adds a unit test to validate this behavior.