### PR TITLE
[Feature] Optimize floors visited for least travel time

### DIFF
--- a/src/elevator_controller.cpp
+++ b/src/elevator_controller.cpp
@@ -1,31 +1,43 @@
 #include <elevator/elevator_controller.h>
+#include <algorithm>
 #include <vector>
-#include <cmath>
+#include <set>
 
 using namespace std;
 
 RESULT ElevatorController::add_floors(vector<int>& floors, double floor_time) {
     int num_floors = 0;
-    vector<int> floors_visited;
 
-    if (! floors.empty()) {
-        floors_visited.push_back(floors[0]);
-    };
+    if (floors.size() > 1) {
+        int first_floor = floors[0];
+        // We want to ensure that duplicates don't show up in the list of floors
+        // that were traveled to
+        set<int> s(floors.begin(), floors.end());
+        floors.assign(s.begin(), s.end());
 
-    for (int i {1}; i < floors.size(); ++i) {
-        int last_floor = floors[i-1];
-        int next_floor = floors[i];
-        // We want consecutively repeated floors to show up once in our list of
-        // visited floors
-        if (next_floor != last_floor) {
-            num_floors += abs(next_floor - last_floor);
-            floors_visited.push_back(next_floor);
+        int max = floors.back();
+        int min = floors[0];
+
+        int first_to_max = max - first_floor;
+        int first_to_min = first_floor - min;
+
+        if (first_to_max > first_to_min) {
+            num_floors = max - min + first_to_min;
+        } else {
+            reverse(floors.begin(), floors.end());
+            num_floors = max - min + first_to_max;
         }
-    };
+
+        vector<int>::iterator first_it = find(floors.begin(), floors.end(), first_floor);
+        int first_idx = distance(floors.begin(), first_it);
+        reverse(floors.begin(), floors.begin() + first_idx);
+        floors.erase(floors.begin() + first_idx);
+        floors.insert(floors.begin(), first_floor);
+    }
 
     RESULT result;
     result.travel_time = num_floors * floor_time;
-    result.floors_visited = floors_visited;
+    result.floors_visited = floors;
 
     return result;
 }

--- a/test/test_elevator.cpp
+++ b/test/test_elevator.cpp
@@ -3,31 +3,15 @@
 #include <vector>
 #include <iostream>
 
-TEST_CASE("Normal elevator operations", "[nominal]") {
-    std::vector<int> floors = {12, 2, 9, 1, 32};
-    ElevatorController controller;
-    RESULT result = controller.add_floors(floors);
-    REQUIRE(result.travel_time == 560);
-    REQUIRE(result.floors_visited == floors);
-};
-
-TEST_CASE("Repeated consecutive floors given", "[repeated]") {
-    std::vector<int> floors = {12, 12, 2, 9, 9, 9, 1, 32, 32};
-    ElevatorController controller;
-    RESULT result = controller.add_floors(floors);
-    REQUIRE(result.travel_time == 560);
-    std::vector<int> floors_visited = {12, 2, 9, 1, 32};
-    REQUIRE(result.floors_visited == floors_visited);
-};
-
 TEST_CASE("Modified floor travel time", "[floor_time]") {
     std::vector<int> floors = {12, 2, 9, 1, 32};
     double floor_time = 8.6;
     ElevatorController controller;
     RESULT result = controller.add_floors(floors, floor_time);
-    int travel_time_comp = result.travel_time - 481.6;
+    int travel_time_comp = result.travel_time - 361.2;
     REQUIRE(travel_time_comp == 0);
-    REQUIRE(result.floors_visited == floors);
+    std::vector<int> floors_visited = {12, 9, 2, 1, 32};
+    REQUIRE(result.floors_visited == floors_visited);
 };
 
 TEST_CASE("First floor only", "[first_only]") {
@@ -44,4 +28,40 @@ TEST_CASE("No floors given", "[no_floors]") {
     RESULT result = controller.add_floors(floors);
     REQUIRE(result.travel_time == 0);
     REQUIRE(result.floors_visited == floors);
+};
+
+TEST_CASE("Optimal travel time downwards", "[optimal]") {
+    std::vector<int> floors = {12, 12, 2, 9, 1, 8, 8};
+    ElevatorController controller;
+    RESULT result = controller.add_floors(floors);
+    REQUIRE(result.travel_time == 110);
+    std::vector<int> floors_visited = {12, 9, 8, 2, 1};
+    REQUIRE(result.floors_visited == floors_visited);
+};
+
+TEST_CASE("Optimal travel time upwards", "[optimal]") {
+    std::vector<int> floors = {12, 32, 25, 32, 13, 13, 27, 25};
+    ElevatorController controller;
+    RESULT result = controller.add_floors(floors);
+    REQUIRE(result.travel_time == 200);
+    std::vector<int> floors_visited = {12, 13, 25, 27, 32};
+    REQUIRE(result.floors_visited == floors_visited);
+};
+
+TEST_CASE("Optimal travel time down first", "[optimal]") {
+    std::vector<int> floors = {12, 12, 32, 9, 27, 11, 9, 11};
+    ElevatorController controller;
+    RESULT result = controller.add_floors(floors);
+    REQUIRE(result.travel_time == 260);
+    std::vector<int> floors_visited = {12, 11, 9, 27, 32};
+    REQUIRE(result.floors_visited == floors_visited);
+};
+
+TEST_CASE("Optimal travel time up first", "[optimal]") {
+    std::vector<int> floors = {12, 1, 12, 1, 19, 3, 15, 15, 15};
+    ElevatorController controller;
+    RESULT result = controller.add_floors(floors);
+    REQUIRE(result.travel_time == 250);
+    std::vector<int> floors_visited = {12, 15, 19, 3, 1};
+    REQUIRE(result.floors_visited == floors_visited);
 };


### PR DESCRIPTION
This introduces the functionality for the elevator to choose the order in which to visit floors to ultimately reduce the total travel time as well as the time to wait in the elevator. For example, given a set of floors 1, 3, 12, 15, 19 (where 12 is the starting point) the elevator will choose to travel 12, 15, 19, 3, 1. In the example given, the shortest total path is to travel upwards first then downwards. Also note that the order of the floors is such that the elevator visits each floor in either direction before visiting the highest and lowest floors.